### PR TITLE
removed key bindings.

### DIFF
--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,3 +1,10 @@
+/*
+below is the format for keybindings, 
+add it in preferences->package settings->Cprettify->keyboard shortcut(user)
+*/
+
+/*
+
 [{
   "keys": ["ctrl+alt+p","f"],
   "command": "cprettify_file"
@@ -5,3 +12,5 @@
   "keys": ["ctrl+alt+p","s"],
   "command": "only_selection"
 }]
+
+*/


### PR DESCRIPTION
(the same can be used from command palatte).

one of the reasons to remove the keyboard shortcut is
becuase of the presence of command palatte,

removed keyboard shortcuts, but provided the format
by commenting the code necessary for keyboard
shortcut in default file, the user can set the
keyboard shortcut from "preferences->package
settings->Cprettify->keyboard shortcut(user)".